### PR TITLE
base_dir variable and quota comment

### DIFF
--- a/notebooks/Auto provision a new user.ipynb
+++ b/notebooks/Auto provision a new user.ipynb
@@ -29,7 +29,7 @@
     "cluster = 'XXXXX'    # Qumulo cluster hostname or IP where you're setting up users\n",
     "api_user = 'XXXXX'     # Qumulo api user name\n",
     "api_password = 'XXXXX' # Qumulo api password\n",
-    "base_directory = 'XXXXX' # the parent path where the users will be created.\n",
+    "base_dir = 'XXXXX' # the parent path where the users will be created.\n",
     "\n",
     "user_name = 'XXXXX' # the new \"user\" to set up."
    ]

--- a/notebooks/Auto provision a new user.ipynb
+++ b/notebooks/Auto provision a new user.ipynb
@@ -9,6 +9,7 @@
     "- Create a home directory\n",
     "- Create NFS export\n",
     "- Create SMB share\n",
+    "- Create quota\n",
     "- Set up daily snapshots\n",
     "\n",
     "### Prerequisites\n",


### PR DESCRIPTION
Not entirely necessary, but I added a quota line to the comments for completeness.
Script failed because it set "base_directory" variable but called "base_dir".